### PR TITLE
Update jekyll-liquify.rb

### DIFF
--- a/lib/jekyll-liquify.rb
+++ b/lib/jekyll-liquify.rb
@@ -1,8 +1,14 @@
 require 'redcarpet'
 
-module LiquidFilter
-  def liquify(input)
-    Liquid::Template.parse(input).render(@context)
+module Jekyll
+  module LiquifyFilter
+    def liquify(input)
+      if input.is_a? String
+        Liquid::Template.parse(input).render(@context)
+      else
+        input
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Handle non-strings. For example, I have a post.title with value 1300 and this plugin borked on post.title|liquify since one of them is an integer. This fixes it.